### PR TITLE
Implement optional `options` argument for changeset.save

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -127,16 +127,17 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      * Executes the changeset and saves the underlying content.
      *
      * @public
+     * @param  {Object} options optional object to pass to content save method
      * @return {Promise}
      */
-    save() {
+    save(options) {
       let content = get(this, CONTENT);
 
       if (typeOf(content.save) === 'function') {
         this.execute();
 
         return content
-          .save()
+          .save(options)
           .then(() => this.rollback());
       }
     },

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -115,16 +115,19 @@ test('#execute does not apply changes to content if invalid', function(assert) {
 
 test('#save proxies to content', function(assert) {
   let result;
-  set(dummyModel, 'save', () => {
+  let options;
+  set(dummyModel, 'save', (dummyOptions) => {
     result = 'ok';
+    options = dummyOptions;
     return resolve(true);
   });
   let dummyChangeset = new Changeset(dummyModel);
   dummyChangeset.set('name', 'foo');
 
   assert.equal(result, undefined, 'precondition');
-  dummyChangeset.save();
+  dummyChangeset.save('test options');
   assert.equal(result, 'ok', 'should save');
+  assert.equal(options, 'test options', 'should proxy options when saving');
 });
 
 test('#rollback restores old values', function(assert) {


### PR DESCRIPTION
Enable ember-data [record.save(options)](https://github.com/emberjs/data/blob/v2.6.1/addon/-private/system/model/model.js#L704) in order to leverage things like [adapterOptions](https://github.com/emberjs/data/blob/v2.6.1/addon/-private/system/snapshot.js#L34-L39) when saving a changeset that has an ember-data model as its content.