### PR TITLE
Fix bug where virtual properties were not being notified when changed

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -341,12 +341,14 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
           this.notifyPropertyChange(ERRORS);
         }
 
+        set(changes, key, value);
         this.notifyPropertyChange(CHANGES);
+        this.notifyPropertyChange(key);
 
-        return set(changes, key, value);
-      } else {
-        return this.addError(key, { value, validation });
+        return value;
       }
+
+      return this.addError(key, { value, validation });
     },
 
     /**

--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -88,3 +88,23 @@ test('it can be used with 1 argument', function(assert) {
   run(() => this.$('button:contains("Submit")').click());
   assert.notOk(this.$('p:contains("There were one or more errors in your form.")').length, 'does not turn invalid');
 });
+
+test('it updates when set', function(assert) {
+  this.set('dummyModel', { firstName: 'Jim', lastName: 'Bob' });
+  this.render(hbs`
+    {{#with (changeset dummyModel) as |changeset|}}
+      <h1>{{changeset.firstName}} {{changeset.lastName}}</h1>
+      <input
+        id="first-name"
+        type="text"
+        value={{changeset.firstName}}
+        onchange={{action (mut changeset.firstName) value="target.value"}}>
+      {{input id="last-name" value=changeset.lastName}}
+    {{/with}}
+  `);
+
+  assert.ok(this.$('h1:contains("Jim Bob")'), 'precondition');
+  run(() => this.$('#first-name').val('foo').trigger('change'));
+  run(() => this.$('#last-name').val('foo').trigger('change'));
+  assert.ok(this.$('h1:contains("foo bar")'), 'should update observable value');
+});


### PR DESCRIPTION
This was causing an issue where observing a value on the changeset (e.g.
in the template) would not work.