### PR TITLE
Fix `Changeset#get` for properties with blank values

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -361,10 +361,12 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     _valueFor(key) {
       let changes = get(this, CHANGES);
       let content = get(this, CONTENT);
-      let changedValue = get(changes, key);
-      let originalValue = get(content, key);
 
-      return isPresent(changedValue) ? changedValue : originalValue;
+      if (changes.hasOwnProperty(key)) {
+        return get(changes, key);
+      } else {
+        return get(content, key);
+      }
     }
   });
 }

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -66,6 +66,15 @@ test('#get returns change if present', function(assert) {
   assert.equal(result, 'Milton Waddams', 'should proxy to change');
 });
 
+test('#get returns change that is a blank value', function(assert) {
+  set(dummyModel, 'name', 'Jim Bob');
+  let dummyChangeset = new Changeset(dummyModel);
+  set(dummyChangeset, 'name', '');
+  let result = get(dummyChangeset, 'name');
+
+  assert.equal(result, '', 'should proxy to change');
+});
+
 test('#set adds a change if valid', function(assert) {
   let expectedChanges = [{ key: 'name', value: 'foo' }];
   let dummyChangeset = new Changeset(dummyModel);


### PR DESCRIPTION
This commit fixes a problem where changes in the changeset object could
not be retrieved if the value was something like `undefined`, `null`,
`''`, etc.

This issue was not a problem at the moment of executing the changes in
the original object, but it was a problem when you rely on the temporary
changes for other things (e.g external computed properties, template).