### PR TITLE
Fix issue with `unknownProperty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ get(changeset, 'isDirty'); // true
 
 #### `get`
 
-Exactly the same semantics as `Ember.get`. This proxies to the underlying Object, or the changed value if present.
+Exactly the same semantics as `Ember.get`. This proxies first to the error value, the changed value, and finally to the underlying Object.
 
 ```js
 get(changeset, 'firstName'); // "Jim"

--- a/addon/index.js
+++ b/addon/index.js
@@ -368,7 +368,12 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      */
     _valueFor(key) {
       let changes = get(this, CHANGES);
+      let errors = get(this, ERRORS);
       let content = get(this, CONTENT);
+
+      if (errors.hasOwnProperty(key)) {
+        return get(errors, `${key}.value`);
+      }
 
       if (changes.hasOwnProperty(key)) {
         return get(changes, key);


### PR DESCRIPTION
Prior to this commit, `changeset.get` would only retrieve the value from
the changes object or the underlying model itself. The problem with this
is that when an input contains an invalid value (let's say this is "foo"
in an email-only input), the `changes` object will only contain the last
valid value, and thus the input resets when attempting to call
`validate`. This commit makes it so that `unknownProperty` will also
fetch the value from the error object, which ensures that
`changeset.get` is in sync with the input.

Closes #60