### PR TITLE
Fix rollback error issue

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -172,17 +172,18 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     },
 
     /**
-     * Returns the changeset to its pristine state, and discards changes.
+     * Returns the changeset to its pristine state, and discards changes and
+     * errors.
      *
      * @public
      * @return {Changeset}
      */
     rollback() {
       // notify virtual properties
-      let changeKeys = keys(get(this, CHANGES));
+      let rollbackKeys = [...keys(get(this, CHANGES)), ...keys(get(this, ERRORS))];
 
-      for (let i = 0; i < changeKeys.length; i++) {
-        this.notifyPropertyChange(changeKeys[i]);
+      for (let i = 0; i < rollbackKeys.length; i++) {
+        this.notifyPropertyChange(rollbackKeys[i]);
       }
 
       set(this, CHANGES, {});

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -172,17 +172,21 @@ test('#save proxies to content', function(assert) {
 });
 
 test('#rollback restores old values', function(assert) {
-  let dummyChangeset = new Changeset(dummyModel);
-  let expectedResult = [
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedChanges = [
     { key: 'firstName', value: 'foo' },
     { key: 'lastName', value: 'bar' }
   ];
+  let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
   dummyChangeset.set('firstName', 'foo');
   dummyChangeset.set('lastName', 'bar');
+  dummyChangeset.set('name', '');
 
-  assert.deepEqual(get(dummyChangeset, 'changes'), expectedResult, 'precondition');
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'precondition');
+  assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
   dummyChangeset.rollback();
   assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should rollback');
+  assert.deepEqual(get(dummyChangeset, 'errors'), [], 'should rollback');
 });
 
 test('#rollback resets valid state', function(assert) {


### PR DESCRIPTION
`rollback` will now correctly notify all virtual properties

Closes #63