### PR TITLE
Add shortcut to addError method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,9 +433,14 @@ changeset.addError('email', {
   value: 'jim@bob.com',
   validation: 'Email already taken'
 });
+
+// shortcut
+changeset.addError('email', 'Email already taken');
 ```
 
 Adding an error manually does not require any special setup. The error will be cleared if the value for the `key` is subsequently set to a valid value.  Adding an error will overwrite any existing error or change for `key`.
+
+If using the shortcut method, the value in the changeset will be used as the value for the error.
 
 **[⬆️ back to top](#api)**
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -264,14 +264,19 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      * @param {Any} options.value
      * @param {Any} options.validation Validation message
      */
-    addError(key, { value, validation }) {
+    addError(key, options) {
       let errors = get(this, ERRORS);
+
+      if (!isObject(options)) {
+        let value = get(this, key);
+        options = { value, validation: options };
+      }
 
       this._deleteKey(CHANGES, key);
       this.notifyPropertyChange(ERRORS);
       this.notifyPropertyChange(key);
 
-      return set(errors, key, { value, validation });
+      return set(errors, key, options);
     },
 
     /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -341,6 +341,18 @@ test('#addError adds an error to the changeset', function(assert) {
   assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
 });
 
+test('#addError adds an error to the changeset using the shortcut', function (assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('email', 'jim@bob.com');
+  dummyChangeset.addError('email', 'Email already taken');
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  assert.equal(get(dummyChangeset, 'error.email.validation'), 'Email already taken', 'should add the error');
+  assert.equal(get(dummyChangeset, 'error.email.value'), 'jim@bob.com', 'addError uses already present value');
+  dummyChangeset.set('email', 'unique@email.com');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
 test('#snapshot creates a snapshot of the changeset', function(assert) {
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   dummyChangeset.set('name', 'Pokemon Go');


### PR DESCRIPTION
So I'm totally willing to have this closed if it's not something wanted; however, it is a change that made several things easier in the Ghost validations implementation.

Basically, this allows one to only pass in a string as the second argument to `addError`. If that is done, the value that exists in the changeset for the specified key will be used as the key for the error.