### PR TITLE
Always persist changes on #save

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -163,13 +163,15 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     save(options) {
       let content = get(this, CONTENT);
 
+      this.execute();
+      let savePromise = resolve(this);
       if (typeOf(content.save) === 'function') {
-        this.execute();
-
-        return content
-          .save(options)
-          .then(() => this.rollback());
+        savePromise = content
+          .save(options);
       }
+
+      return savePromise
+        .then(() => this.rollback());
     },
 
     /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -171,6 +171,16 @@ test('#save proxies to content', function(assert) {
   assert.equal(options, 'test options', 'should proxy options when saving');
 });
 
+test('#save proxyes to content even if it does not implement #save', function(assert) {
+  let person = {name: 'Jim'};
+  let dummyChangeset = new Changeset(person);
+  dummyChangeset.set('name', 'foo');
+
+  return dummyChangeset.save().then(() => {
+    assert.equal(get(person, 'name'), 'foo', 'persist changes to content');
+  });
+});
+
 test('#rollback restores old values', function(assert) {
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   let expectedChanges = [

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -171,7 +171,7 @@ test('#save proxies to content', function(assert) {
   assert.equal(options, 'test options', 'should proxy options when saving');
 });
 
-test('#save proxyes to content even if it does not implement #save', function(assert) {
+test('#save proxies to content even if it does not implement #save', function(assert) {
   let person = {name: 'Jim'};
   let dummyChangeset = new Changeset(person);
   dummyChangeset.set('name', 'foo');


### PR DESCRIPTION
Even if the content object does not implement the save function, persists the changes on #save and returns a Promise.