### PR TITLE
Fix logic for `isPristine`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,17 @@ Returns a Boolean value of the changeset's state. A pristine changeset is one wi
 get(changeset, 'isPristine'); // true
 ```
 
+If changes present on the changeset are equal to the content's, this will return `true`. However, note that key/value pairs in the list of changes must all be present and equal on the content, but not vice versa:
+
+```js
+let user = { name: 'Bobby', age: 21 };
+changeset.set('name', 'Bobby');
+changeset.get('isPristine'); // true
+
+changeset.set('foo', 'bar');
+changeset.get('isPristine'); // false
+```
+
 **[⬆️ back to top](#api)**
 
 #### `isDirty`

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import objectToArray from 'ember-changeset/utils/computed/object-to-array';
 import isEmptyObject from 'ember-changeset/utils/computed/is-empty-object';
+import objectEqual from 'ember-changeset/utils/computed/object-equal';
 import isPromise from 'ember-changeset/utils/is-promise';
 import isObject from 'ember-changeset/utils/is-object';
 import pureAssign from 'ember-changeset/utils/assign';
@@ -60,7 +61,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     error: readOnly(ERRORS),
 
     isValid: isEmptyObject(ERRORS),
-    isPristine: isEmptyObject(CHANGES),
+    isPristine: objectEqual(CHANGES, CONTENT),
     isInvalid: not('isValid').readOnly(),
     isDirty: not('isPristine').readOnly(),
 

--- a/addon/utils/computed/object-equal.js
+++ b/addon/utils/computed/object-equal.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+
+const { computed, get } = Ember;
+const { keys } = Object;
+
+/**
+ * Shallow object comparison computed property. Checks all key/value pairs on
+ * the first object and compares against the second object. Essentially, this
+ * means that the second object must have the same key/values as the first, but
+ * not vice versa.
+ *
+ * @public
+ * @param  {String} sourceKey dependent key for first object
+ * @param  {String} compareKey dependent key for second object
+ * @return {Boolean}
+ */
+export default function objectEqual(sourceKey, compareKey) {
+  return computed(sourceKey, compareKey, function() {
+    let source = get(this, sourceKey);
+    let compare = get(this, compareKey);
+
+    return keys(source)
+      .reduce((acc, key) => acc && get(source, key) === get(compare, key), true);
+  }).readOnly();
+}

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -437,6 +437,40 @@ test('#cast noops if no keys are passed', function(assert) {
   assert.deepEqual(dummyChangeset.get('changes'), expectedResult, 'should drop `unwantedProp');
 });
 
+test("isPristine returns true if changes are equal to content's values", function(assert) {
+  dummyModel.set('name', 'Bobby');
+  dummyModel.set('thing', 123);
+  dummyModel.set('nothing', null);
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'Bobby');
+  dummyChangeset.set('nothing', null);
+
+  assert.ok(dummyChangeset.get('isPristine'), 'should be pristine');
+});
+
+test("isPristine returns false if changes are not equal to content's values", function(assert) {
+  dummyModel.set('name', 'Bobby');
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'Bobby');
+  dummyChangeset.set('thing', 123);
+
+  assert.notOk(dummyChangeset.get('isPristine'), 'should not be pristine');
+});
+
+test('isPristine works with `null` values', function(assert) {
+  dummyModel.set('name', null);
+  dummyModel.set('age', 15);
+  let dummyChangeset = new Changeset(dummyModel);
+
+  assert.ok(dummyChangeset.get('isPristine'), 'should be pristine');
+
+  dummyChangeset.set('name', 'Kenny');
+  assert.notOk(dummyChangeset.get('isPristine'), 'should not be pristine');
+
+  dummyChangeset.set('name', null);
+  assert.ok(dummyChangeset.get('isPristine'), 'should be pristine');
+});
+
 // Behavior
 test('it works with setProperties', function(assert) {
   let dummyChangeset = new Changeset(dummyModel);

--- a/tests/unit/utils/computed/object-equal-test.js
+++ b/tests/unit/utils/computed/object-equal-test.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+import objectEqual from 'ember-changeset/utils/computed/object-equal';
+import { module, test } from 'qunit';
+
+const {
+  Object: EmberObject,
+  run
+} = Ember;
+
+module('Unit | Utility | computed/object equal');
+
+test('it returns true if all first obj KV pairs are present and equal to second obj', function(assert) {
+  let Thing = EmberObject.extend({
+    first: { name: 'Jim Bob' },
+    second: { name: 'Jim Bob', age: 21 },
+    isFirstEqualToSecond: objectEqual('first', 'second')
+  });
+  let theThing = Thing.create();
+  let result = theThing.get('isFirstEqualToSecond');
+
+  assert.ok(result);
+});
+
+test('it returns false if not all first obj KV pairs are present and equal to second obj', function(assert) {
+  let Thing = EmberObject.extend({
+    first: { name: 'Jim Bob', age: 21 },
+    second: { name: 'Jim Bob' },
+    isFirstEqualToSecond: objectEqual('first', 'second')
+  });
+  let theThing = Thing.create();
+  let result = theThing.get('isFirstEqualToSecond');
+
+  assert.notOk(result);
+});
+
+test('it returns true if second obj KV pairs are set to equal first obj', function(assert) {
+  let Thing = EmberObject.extend({
+    first: { name: 'Jim Bob' },
+    second: { name: null },
+    isFirstEqualToSecond: objectEqual('first', 'second')
+  });
+  let theThing = Thing.create();
+
+  assert.notOk(theThing.get('isFirstEqualToSecond'));
+
+  run(() => {
+    theThing.set('second', { name: 'Jim Bob' });
+    assert.ok(theThing.get('isFirstEqualToSecond'));
+  });
+});


### PR DESCRIPTION
A changeset is pristine if and only if all changes are present and
equal to values on the underlying content

Closes #101