### PR TITLE
changeset.save() resolves with result of underlying save() promise

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -174,7 +174,8 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
         savePromise = content.save(options);
       }
 
-      return savePromise.then(() => this.rollback());
+      savePromise.then(() => this.rollback());
+      return savePromise;
     },
 
     /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -160,15 +160,19 @@ test('#save proxies to content', function(assert) {
   set(dummyModel, 'save', (dummyOptions) => {
     result = 'ok';
     options = dummyOptions;
-    return resolve(true);
+    return resolve('saveResult');
   });
   let dummyChangeset = new Changeset(dummyModel);
   dummyChangeset.set('name', 'foo');
 
   assert.equal(result, undefined, 'precondition');
-  dummyChangeset.save('test options');
+  let promise = dummyChangeset.save('test options');
   assert.equal(result, 'ok', 'should save');
   assert.equal(options, 'test options', 'should proxy options when saving');
+  assert.ok(!!promise && typeof promise.then === 'function', 'save returns a promise');
+  promise.then((saveResult) => {
+    assert.equal(saveResult, 'saveResult', 'save proxies to save promise of content');
+  });
 });
 
 test('#save proxies to content even if it does not implement #save', function(assert) {


### PR DESCRIPTION
Fix for #116 