### PR TITLE
Pass original object into validation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export default Controller.extend({
       return changeset.rollback();
     },
 
-    validate({ key, newValue, oldValue, changes, object }) {
+    validate({ key, newValue, oldValue, changes, content }) {
       // lookup a validator function on your favorite validation library
       // should return a Boolean
     }
@@ -523,7 +523,7 @@ const { Controller } = Ember;
 
 export default Controller.extend({
   actions: {
-    validate({ key, newValue, oldValue, changes, object }) {
+    validate({ key, newValue, oldValue, changes, content }) {
       // lookup a validator function on your favorite validation library
       // should return a Boolean
     }
@@ -537,7 +537,7 @@ export default Controller.extend({
 {{dummy-form changeset=(changeset model (action "validate"))}}
 ```
 
-Your action will receive a single POJO containing the `key`, `newValue`, `oldValue` and a one way reference to `changes`.
+Your action will receive a single POJO containing the `key`, `newValue`, `oldValue`, a one way reference to `changes`, and the original object `content`.
 
 ## Handling Server Errors
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export default Controller.extend({
       return changeset.rollback();
     },
 
-    validate({ key, newValue, oldValue, changes }) {
+    validate({ key, newValue, oldValue, changes, object }) {
       // lookup a validator function on your favorite validation library
       // should return a Boolean
     }
@@ -523,7 +523,7 @@ const { Controller } = Ember;
 
 export default Controller.extend({
   actions: {
-    validate({ key, newValue, oldValue, changes }) {
+    validate({ key, newValue, oldValue, changes, object }) {
       // lookup a validator function on your favorite validation library
       // should return a Boolean
     }

--- a/addon/index.js
+++ b/addon/index.js
@@ -385,13 +385,15 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     _validate(key, newValue, oldValue) {
       let changes = get(this, CHANGES);
       let validator = get(this, VALIDATOR);
+      let content = get(this, CONTENT);
 
       if (typeOf(validator) === 'function') {
         let isValid = validator({
           key,
           newValue,
           oldValue,
-          changes: pureAssign(changes)
+          changes: pureAssign(changes),
+          content,
         });
 
         return isPresent(isValid) ? isValid : true;

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -21,12 +21,12 @@ let dummyValidations = {
   password(value) {
     return value || ['foo', 'bar'];
   },
-  passwordConfirmation(newValue, _oldValue, { password: changedPassword }, { password } = {}) {
+  passwordConfirmation(newValue, _oldValue, { password: changedPassword }, { password }) {
     return isPresent(newValue) && (changedPassword === newValue || password === newValue) || "password doesn't match";
   },
   async(value) {
     return resolve(value);
-  },
+  }
 };
 
 function dummyValidator({ key, newValue, oldValue, changes, content }) {


### PR DESCRIPTION
This addresses https://github.com/DockYard/ember-changeset-validations/issues/99. The rationale is that if a property hasn't been set on a changeset, it won't show up in the `changes` object, so one can look in the original `object` instead.