### PR TITLE
ensure Changeset#save returns the whole promise

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -175,8 +175,10 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
         savePromise = content.save(options);
       }
 
-      savePromise.then(() => this.rollback());
-      return savePromise;
+      return savePromise.then((result) => {
+        this.rollback();
+        return result;
+      });
     },
 
     /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 const {
   Object: EmberObject,
-  RSVP: { resolve },
+  RSVP: { resolve, Promise },
   String: { dasherize },
   run,
   get,
@@ -12,6 +12,10 @@ const {
   set,
   typeOf
 } = Ember;
+
+const {
+  next
+} = run;
 
 let dummyModel;
 let dummyValidations = {
@@ -182,18 +186,16 @@ test('#save handles rejected proxy content', function(assert) {
   assert.expect(1);
 
   set(dummyModel, 'save', () => {
-    return new Ember.RSVP.Promise(function (resolve, reject) {
-      Ember.run.next(null, reject, new Error('some ember data error'));
+    return new Promise((resolve, reject) => {
+      next(null, reject, new Error('some ember data error'));
     });
   });
 
-  Ember.run(() => {
+  run(() => {
     dummyChangeset.save().catch((error) => {
         assert.equal(error.message, 'some ember data error');
       })
-      .finally(() => {
-        done();
-      });
+      .finally(() => done());
   });
 });
 

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -191,7 +191,9 @@ test('#save handles rejected proxy content', function(assert) {
     dummyChangeset.save().catch((error) => {
         assert.equal(error.message, 'some ember data error');
       })
-      .finally(() => done());
+      .finally(() => {
+        done();
+      });
   });
 });
 

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -175,6 +175,26 @@ test('#save proxies to content', function(assert) {
   });
 });
 
+test('#save handles rejected proxy content', function(assert) {
+  let done = assert.async();
+  let dummyChangeset = new Changeset(dummyModel);
+
+  assert.expect(1);
+
+  set(dummyModel, 'save', () => {
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      Ember.run.next(null, reject, new Error('some ember data error'));
+    });
+  });
+
+  Ember.run(() => {
+    dummyChangeset.save().catch((error) => {
+        assert.equal(error.message, 'some ember data error');
+      })
+      .finally(() => done());
+  });
+});
+
 test('#save proxies to content even if it does not implement #save', function(assert) {
   let done = assert.async();
   let person = { name: 'Jim' };


### PR DESCRIPTION
This handles for uncaught errors when Ember Data would encounter a server side error and reject the promise.