### PR TITLE
Support complex objects, don't mark changes from validate if not changed

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import objectToArray from 'ember-changeset/utils/computed/object-to-array';
 import isEmptyObject from 'ember-changeset/utils/computed/is-empty-object';
-import objectEqual from 'ember-changeset/utils/computed/object-equal';
 import isPromise from 'ember-changeset/utils/is-promise';
 import isObject from 'ember-changeset/utils/is-object';
 import pureAssign from 'ember-changeset/utils/assign';
@@ -18,6 +17,7 @@ const {
   assert,
   get,
   isArray,
+  isEqual,
   isNone,
   isPresent,
   set,
@@ -61,7 +61,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     error: readOnly(ERRORS),
 
     isValid: isEmptyObject(ERRORS),
-    isPristine: objectEqual(CHANGES, CONTENT),
+    isPristine: isEmptyObject(CHANGES),
     isInvalid: not('isValid').readOnly(),
     isDirty: not('isPristine').readOnly(),
 
@@ -397,11 +397,11 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
 
       if (isPromise(validation)) {
         return validation.then((resolvedValidation) => {
-          return this._setProperty(resolvedValidation, { key, value });
+          return this._setProperty(resolvedValidation, { key, value, oldValue });
         });
       }
 
-      return this._setProperty(validation, { key, value });
+      return this._setProperty(validation, { key, value, oldValue });
     },
 
     /**
@@ -442,7 +442,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      * @param {Any} options.value
      * @return {Any}
      */
-    _setProperty(validation, { key, value } = {}) {
+    _setProperty(validation, { key, value, oldValue } = {}) {
       let changes = get(this, CHANGES);
       let isSingleValidationArray =
         isArray(validation) &&
@@ -451,7 +451,12 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
 
       if (validation === true || isSingleValidationArray) {
         this._deleteKey(ERRORS, key);
-        set(changes, key, value);
+
+        if (!isEqual(oldValue, value)) {
+          set(changes, key, value);
+        } else if (obj.hasOwnProperty(key)) {
+          delete changes[key];
+        }
         this.notifyPropertyChange(CHANGES);
         this.notifyPropertyChange(key);
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -55,8 +55,8 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      */
     __changeset__: CHANGESET,
 
-    changes: objectToArray(CHANGES),
-    errors: objectToArray(ERRORS),
+    changes: objectToArray(CHANGES, false),
+    errors: objectToArray(ERRORS, true),
     change: readOnly(CHANGES),
     error: readOnly(ERRORS),
 

--- a/addon/utils/computed/object-to-array.js
+++ b/addon/utils/computed/object-to-array.js
@@ -8,14 +8,14 @@ const {
 const { keys } = Object;
 const assign = Ember.assign || Ember.merge;
 
-export default function objectToArray(objKey) {
+export default function objectToArray(objKey, flattenObjects) {
   return computed(objKey, function() {
     let obj = get(this, objKey);
 
     return keys(obj).map((key) => {
       let value = obj[key];
 
-      if (typeOf(value) === 'object') {
+      if (flattenObjects && typeOf(value) === 'object') {
         return assign({ key }, value);
       }
 

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -408,6 +408,45 @@ test('#validate works correctly with complex values', function(assert) {
   });
 });
 
+test('#validate marks actual valid changes', function(assert) {
+  let done = assert.async();
+  dummyModel.setProperties({ name: 'Jim Bob', password: true, passwordConfirmation: true, async: true });
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  dummyChangeset.set('name', 'foo bar');
+  dummyChangeset.set('password', false);
+
+  run(() => {
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'changes'), [{ key: 'name', value: 'foo bar' }]);
+      done();
+    });
+  });
+});
+
+test('#validate does not mark changes when nothing has changed', function(assert) {
+  let done = assert.async();
+  let options = {
+    persist: true,
+    // test isEqual to ensure we're using Ember.isEqual for comparison
+    isEqual(other) {
+      return this.persist === other.persist;
+    }
+  };
+  dummyModel.setProperties({ name: 'Jim Bob', password: true, passwordConfirmation: true, async: true, options});
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  dummyChangeset.set('options', options);
+
+  run(() => {
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'error'), {});
+      assert.deepEqual(get(dummyChangeset, 'changes'), []);
+      done();
+    });
+  });
+});
+
 test('#addError adds an error to the changeset', function(assert) {
   let dummyChangeset = new Changeset(dummyModel);
   dummyChangeset.addError('email', {

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -30,6 +30,9 @@ let dummyValidations = {
   },
   async(value) {
     return resolve(value);
+  },
+  options(value) {
+    return isPresent(value);
   }
 };
 
@@ -328,14 +331,14 @@ test('#merge preserves content and validator of origin changeset', function(asse
 
 test('#validate/0 validates all fields immediately', function(assert) {
   let done = assert.async();
-  dummyModel.setProperties({ name: 'J', password: false });
+  dummyModel.setProperties({ name: 'J', password: false, options: null });
   let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
 
   run(() => {
     dummyChangeset.validate().then(() => {
       assert.deepEqual(get(dummyChangeset, 'error.password'), { validation: ['foo', 'bar'], value: false }, 'should validate immediately');
       assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should not set changes');
-      assert.equal(get(dummyChangeset, 'errors.length'), 4, 'should have 4 errors');
+      assert.equal(get(dummyChangeset, 'errors.length'), 5, 'should have 5 errors');
       done();
     });
   });
@@ -358,7 +361,7 @@ test('#validate/1 validates a single field immediately', function(assert) {
 
 test('#validate works correctly with changeset values', function(assert) {
   let done = assert.async();
-  dummyModel.setProperties({ name: undefined, password: false, async: true, passwordConfirmation: false });
+  dummyModel.setProperties({ name: undefined, password: false, async: true, passwordConfirmation: false, options: {}});
   let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
 
   run(() => {
@@ -386,6 +389,20 @@ test('#validate works correctly with changeset values', function(assert) {
     dummyChangeset.validate().then(() => {
       assert.equal(get(dummyChangeset, 'errors.length'), 0, 'should have no errors');
       assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+      done();
+    });
+  });
+});
+
+test('#validate works correctly with complex values', function(assert) {
+  let done = assert.async();
+  dummyModel.setProperties({});
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  run(() => {
+    dummyChangeset.set('options', { persist: true });
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'changes.0'), { key: 'options', value: { persist: true }});
       done();
     });
   });

--- a/tests/unit/utils/computed/object-to-array-test.js
+++ b/tests/unit/utils/computed/object-to-array-test.js
@@ -23,7 +23,7 @@ test('it converts an object into an array', function(assert) {
   assert.deepEqual(result, expectedResult, 'should convert to array');
 });
 
-test('it works with values as shallow objects', function(assert) {
+test('it maintains shallow objects when flattenObjects is false', function(assert) {
   let Dummy = EmberObject.extend({
     _object: {
       firstName: {
@@ -32,7 +32,23 @@ test('it works with values as shallow objects', function(assert) {
       }
     },
 
-    values: objectToArray('_object')
+    values: objectToArray('_object', false)
+  });
+  let result = Dummy.create().get('values');
+  let expectedResult = [{ key: 'firstName', value: { value: 'Jim', validation: 'Too short' }}];
+  assert.deepEqual(result, expectedResult, 'should convert to array');
+});
+
+test('it flattens shallow object values when flattenObjects is true', function(assert) {
+  let Dummy = EmberObject.extend({
+    _object: {
+      firstName: {
+        value: 'Jim',
+        validation: 'Too short'
+      }
+    },
+
+    values: objectToArray('_object', true)
   });
   let result = Dummy.create().get('values');
   let expectedResult = [{ key: 'firstName', value: 'Jim', validation: 'Too short' }];


### PR DESCRIPTION
This is my attempt at fixing #132. I'm not sure if the description there was accurate (`validate` only setting `errors` and never setting `changes`). I tried doing that, but a ton of tests broke. I settled on an implementation that only touches `changes` for keys that have actually changed.

Fixes #132. Hopefully!

*Update*: Also includes the change from #144.