### PR TITLE
support complex values

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -55,8 +55,8 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      */
     __changeset__: CHANGESET,
 
-    changes: objectToArray(CHANGES),
-    errors: objectToArray(ERRORS),
+    changes: objectToArray(CHANGES, false),
+    errors: objectToArray(ERRORS, true),
     change: readOnly(CHANGES),
     error: readOnly(ERRORS),
 

--- a/addon/utils/computed/object-to-array.js
+++ b/addon/utils/computed/object-to-array.js
@@ -8,14 +8,14 @@ const {
 const { keys } = Object;
 const assign = Ember.assign || Ember.merge;
 
-export default function objectToArray(objKey) {
+export default function objectToArray(objKey, flattenObjects) {
   return computed(objKey, function() {
     let obj = get(this, objKey);
 
     return keys(obj).map((key) => {
       let value = obj[key];
 
-      if (typeOf(value) === 'object') {
+      if (flattenObjects && typeOf(value) === 'object') {
         return assign({ key }, value);
       }
 

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -30,6 +30,9 @@ let dummyValidations = {
   },
   async(value) {
     return resolve(value);
+  },
+  options(value) {
+    return isPresent(value);
   }
 };
 
@@ -328,14 +331,14 @@ test('#merge preserves content and validator of origin changeset', function(asse
 
 test('#validate/0 validates all fields immediately', function(assert) {
   let done = assert.async();
-  dummyModel.setProperties({ name: 'J', password: false });
+  dummyModel.setProperties({ name: 'J', password: false, options: null });
   let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
 
   run(() => {
     dummyChangeset.validate().then(() => {
       assert.deepEqual(get(dummyChangeset, 'error.password'), { validation: ['foo', 'bar'], value: false }, 'should validate immediately');
       assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should not set changes');
-      assert.equal(get(dummyChangeset, 'errors.length'), 4, 'should have 4 errors');
+      assert.equal(get(dummyChangeset, 'errors.length'), 5, 'should have 5 errors');
       done();
     });
   });
@@ -358,7 +361,7 @@ test('#validate/1 validates a single field immediately', function(assert) {
 
 test('#validate works correctly with changeset values', function(assert) {
   let done = assert.async();
-  dummyModel.setProperties({ name: undefined, password: false, async: true, passwordConfirmation: false });
+  dummyModel.setProperties({ name: undefined, password: false, async: true, passwordConfirmation: false, options: {}});
   let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
 
   run(() => {
@@ -386,6 +389,20 @@ test('#validate works correctly with changeset values', function(assert) {
     dummyChangeset.validate().then(() => {
       assert.equal(get(dummyChangeset, 'errors.length'), 0, 'should have no errors');
       assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+      done();
+    });
+  });
+});
+
+test('#validate works correctly with complex values', function(assert) {
+  let done = assert.async();
+  dummyModel.setProperties({});
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  run(() => {
+    dummyChangeset.set('options', { persist: true });
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'changes.0'), { key: 'options', value: { persist: true }});
       done();
     });
   });

--- a/tests/unit/utils/computed/object-to-array-test.js
+++ b/tests/unit/utils/computed/object-to-array-test.js
@@ -23,7 +23,7 @@ test('it converts an object into an array', function(assert) {
   assert.deepEqual(result, expectedResult, 'should convert to array');
 });
 
-test('it works with values as shallow objects', function(assert) {
+test('it maintains shallow objects when flattenObjects is false', function(assert) {
   let Dummy = EmberObject.extend({
     _object: {
       firstName: {
@@ -32,7 +32,23 @@ test('it works with values as shallow objects', function(assert) {
       }
     },
 
-    values: objectToArray('_object')
+    values: objectToArray('_object', false)
+  });
+  let result = Dummy.create().get('values');
+  let expectedResult = [{ key: 'firstName', value: { value: 'Jim', validation: 'Too short' }}];
+  assert.deepEqual(result, expectedResult, 'should convert to array');
+});
+
+test('it flattens shallow object values when flattenObjects is true', function(assert) {
+  let Dummy = EmberObject.extend({
+    _object: {
+      firstName: {
+        value: 'Jim',
+        validation: 'Too short'
+      }
+    },
+
+    values: objectToArray('_object', true)
   });
   let result = Dummy.create().get('values');
   let expectedResult = [{ key: 'firstName', value: 'Jim', validation: 'Too short' }];


### PR DESCRIPTION
Don't flatten complex values into the changes object.

Prior to this, if my object looked like:

```js
{ name: 'foo', options: { awesomeMode: true } }
```

After validation, `changeset.get('changes')[0]` would be:

```js
{ key: 'options', awesomeMode: true }
```

With this change, it instead returns:

```js
{ key: 'options', value: { awesomeMode: true }}
```