### PR TITLE
Add option to skip validations when setting values

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -29,10 +29,13 @@ const CONTENT = '_content';
 const CHANGES = '_changes';
 const ERRORS = '_errors';
 const VALIDATOR = '_validator';
+const OPTIONS = '_options';
 
 function defaultValidatorFn() {
   return true;
 }
+
+const defaultOptions = { skipValidationsOnSet: false };
 
 /**
  * Creates new changesets.
@@ -40,9 +43,10 @@ function defaultValidatorFn() {
  * @param  {Object} obj
  * @param  {Function} validateFn
  * @param  {Object} validationMap
+ * @param  {Object}  options
  * @return {Ember.Object}
  */
-export function changeset(obj, validateFn = defaultValidatorFn, validationMap = {}) {
+export function changeset(obj, validateFn = defaultValidatorFn, validationMap = {}, options = {}) {
   assert('Underlying object for changeset is missing', isPresent(obj));
 
   return EmberObject.extend({
@@ -71,6 +75,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
       this[CHANGES] = {};
       this[ERRORS] = {};
       this[VALIDATOR] = validateFn;
+      this[OPTIONS] = Object.assign({}, defaultOptions, options);
     },
 
     /**
@@ -93,7 +98,15 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      * @return {Any}
      */
     setUnknownProperty(key, value) {
-      return this._validateAndSet(key, value);
+      let changesetOptions = get(this, OPTIONS);
+      let skipValidationsOnSet = get(changesetOptions, 'skipValidationsOnSet');
+      
+      if (skipValidationsOnSet) {
+        return this._setProperty(true, { key, value });
+      }
+      else {
+        return this._validateAndSet(key, value);
+      }
     },
 
     /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -107,6 +107,16 @@ test('#set does not add a change if invalid', function(assert) {
   assert.ok(isInvalid, 'should be invalid');
 });
 
+test('#set adds the change without validation if `skipValidationsOnSet` option is set', function(assert) {
+  let expectedChanges = [{ key: 'password', value: false }];
+  
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, null, {skipValidationsOnSet: true});
+  dummyChangeset.set('password', false);
+  let changes = get(dummyChangeset, 'changes');
+  
+  assert.deepEqual(changes, expectedChanges, 'should add change');
+});
+
 test('#prepare provides callback to modify changes', function(assert) {
   let date = new Date();
   let dummyChangeset = new Changeset(dummyModel);


### PR DESCRIPTION
This adds the option to skip validations when setting values to the underlying object. This option would only be available when creating the changeset programmatically by using a forth parameter. The user would be responsible for manually invoking `validate` on their changeset.

In combination with ember-changeset-validations, it would looks like this:

```
  ...
  model() {
    return new Changeset(
       someObject,
       lookupValidator(SomeValidator),
       SomeValidator,
       { skipValidationsOnSet: true }
    );
  }
  ...
```