### PR TITLE
[BUG]: clear errors for ember 1.13.13

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -100,7 +100,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     setUnknownProperty(key, value) {
       let changesetOptions = get(this, OPTIONS);
       let skipValidate = get(changesetOptions, 'skipValidate');
-      
+
       if (skipValidate) {
         return this._setProperty(true, { key, value });
       }
@@ -470,6 +470,12 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
         }
         this.notifyPropertyChange(CHANGES);
         this.notifyPropertyChange(key);
+
+        let errors = get(this, ERRORS);
+        if (errors['__ember_meta__'] && errors['__ember_meta__']['values']) {
+          delete errors['__ember_meta__']['values'][key];
+          set(this, ERRORS, errors);
+        }
 
         return value;
       }

--- a/addon/index.js
+++ b/addon/index.js
@@ -100,7 +100,6 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     setUnknownProperty(key, value) {
       let changesetOptions = get(this, OPTIONS);
       let skipValidate = get(changesetOptions, 'skipValidate');
-
       if (skipValidate) {
         return this._setProperty(true, { key, value });
       }


### PR DESCRIPTION
See this issue for the full [details](https://github.com/DockYard/ember-changeset-validations/issues/127)

In short, the ember 1.13.13 support for this addon is broken when used in connection with `ember-changeset-validations` because the errors are not truly cleared (visually) from the template itself.

This change is [test driven](https://github.com/DockYard/ember-changeset-validations/pull/129) from the validations addon because that provides the most context. It's not impossible to unit test here but I didn't feel the tests added a lot of value. If this is a must please convince me otherwise.

In truth I'm a little unsure how to land this as it only fails under ember 1.13.13 and the tests in `ember-changeset-validations` had nothing to exercise the template/re-render logic.

Feedback welcome - this solves a real problem for ember 1.13.13 users :)