### PR TITLE
allow empty objects

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -120,7 +120,8 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      * @return {String}
      */
     toString() {
-      return `changeset:${get(this, CONTENT).toString()}`;
+      let normalisedContent = pureAssign(get(this, CONTENT), {});
+      return `changeset:${normalisedContent.toString()}`;
     },
 
     /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -762,3 +762,12 @@ test('it clears errors when setting to original value', function(assert) {
   assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
   assert.notOk(get(dummyChangeset, 'isInvalid'), 'should be valid');
 });
+
+test('content can be an empty hash', function(assert) {
+  assert.expect(1);
+
+  let emptyObject = Object.create(null);
+  let dummyChangeset = new Changeset(emptyObject, dummyValidator);
+
+  assert.equal(dummyChangeset.toString(), 'changeset:[object Object]');
+})


### PR DESCRIPTION
Sometimes we use the Ember `hash` helper to create a changeset model. With the new version of glimmer this creates an EmptyObject which has no `toString` function and so can't be called.

This PR assigns the content to normalise it into an object which adds toString and now we can use the hash helper 🎊 