### PR TITLE
Remove changes on set when model is Ember.ObjectProxy

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -291,7 +291,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
       return resolve(this._validateAndSet(key, this._valueFor(key)));
     },
 
-    
+
     /**
      * Checks to see if async validator for a given key has not resolved.
      * If no key is provided it will check to see if any async validator is running.
@@ -495,7 +495,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
 
         if (!isEqual(oldValue, value)) {
           set(changes, key, value);
-        } else if (key in obj) {
+        } else if (key in changes) {
           delete changes[key];
         }
         this.notifyPropertyChange(CHANGES);
@@ -518,7 +518,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
      * for a given key.
      *
      * @private
-     * @param {String} key 
+     * @param {String} key
      * @param {Boolean} value
      */
     _setIsValidating(key, value) {

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -91,6 +91,44 @@ test('#set adds a change if valid', function(assert) {
   assert.deepEqual(changes, expectedChanges, 'should add change');
 });
 
+test('#set removes a change if set back to original value', function(assert) {
+  let model = Ember.Object.create({ name: 'foo' });
+  let dummyChangeset = new Changeset(model);
+
+  dummyChangeset.set('name', 'bar');
+  assert.deepEqual(
+    get(dummyChangeset, 'changes'),
+    [{ key: 'name', value: 'bar' }],
+    'change is added when value is different than original value'
+  );
+
+  dummyChangeset.set('name', 'foo');
+  assert.deepEqual(
+    get(dummyChangeset, 'changes'),
+    [],
+    'change is removed when new value matches original value'
+  );
+});
+
+test('#set removes a change if set back to original value when obj is ProxyObject', function(assert) {
+  let model = Ember.ObjectProxy.create({ content: { name: 'foo' } });
+  let dummyChangeset = new Changeset(model);
+
+  dummyChangeset.set('name', 'bar');
+  assert.deepEqual(
+    get(dummyChangeset, 'changes'),
+    [{ key: 'name', value: 'bar' }],
+    'change is added when value is different than original value'
+  );
+
+  dummyChangeset.set('name', 'foo');
+  assert.deepEqual(
+    get(dummyChangeset, 'changes'),
+    [],
+    'change is removed when new value matches original value'
+  );
+});
+
 test('#set does not add a change if invalid', function(assert) {
   let expectedErrors = [
     { key: 'name', validation: 'too short', value: 'a' },
@@ -112,11 +150,11 @@ test('#set does not add a change if invalid', function(assert) {
 
 test('#set adds the change without validation if `skipValidate` option is set', function(assert) {
   let expectedChanges = [{ key: 'password', value: false }];
-  
+
   let dummyChangeset = new Changeset(dummyModel, dummyValidator, null, {skipValidate: true});
   dummyChangeset.set('password', false);
   let changes = get(dummyChangeset, 'changes');
-  
+
   assert.deepEqual(changes, expectedChanges, 'should add change');
 });
 


### PR DESCRIPTION
`key in obj` does not correctly detect properties that are defined on the underlying object of an `Ember.ObjectProxy`. Since this conditional is for deciding whether or not to delete a key in `changes`, I think it makes sense to check the `changes` object for its existence anyway.

Here's a twiddle showing the problem https://ember-twiddle.com/bac73fd0fd7cae267621638b9621a7bb?openFiles=controllers.application.js%2C