### PR TITLE
Check for changed key on changes, not on the parent changeset obj

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -495,7 +495,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
 
         if (!isEqual(oldValue, value)) {
           set(changes, key, value);
-        } else if (key in obj) {
+        } else if (key in changes) {
           delete changes[key];
         }
         this.notifyPropertyChange(CHANGES);


### PR DESCRIPTION
I noticed that toggling a boolean value on a changeset would make a single change, but subsequent attempts to toggle the boolean were ignored. Digging into the `_setProperty` function, it looks like the `else if (key in obj)` is never triggered because `obj` is the whole parent changeset, in which the key is buried under `_changes` . By checking `get(this, CHANGES)` instead, we found the expected behavior—_i.e._, removing the change when old and new values match.