### PR TITLE
Support non-promise return values from proxied save()

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,8 @@ Note that executing the changeset will not remove the internal list of changes -
 
 #### `save`
 
-Executes changes, then proxies to the underlying Object's `save` method, if one exists. If it does, it expects the method to return a `Promise`.
+Executes changes, then proxies to the underlying Object's `save` method, if one exists. If it does, the method can either return a `Promise` or a non-`Promise` value. Either way, the changeset's `save` method will return
+a promise.
 
 ```js
 changeset.save(); // returns Promise

--- a/addon/index.js
+++ b/addon/index.js
@@ -193,7 +193,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
         savePromise = content.save(options);
       }
 
-      return savePromise.then((result) => {
+      return resolve(savePromise).then((result) => {
         this.rollback();
         return result;
       });

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -231,6 +231,28 @@ test('#save proxies to content', function(assert) {
   }).finally(() => done());
 });
 
+test('#save handles non-promise proxy content', function(assert) {
+  let result;
+  let options;
+  let done = assert.async();
+  set(dummyModel, 'save', (dummyOptions) => {
+    result = 'ok';
+    options = dummyOptions;
+    return 'saveResult';
+  });
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('name', 'foo');
+
+  assert.equal(result, undefined, 'precondition');
+  let promise = dummyChangeset.save('test options');
+  assert.equal(result, 'ok', 'should save');
+  assert.equal(options, 'test options', 'should proxy options when saving');
+  assert.ok(!!promise && typeof promise.then === 'function', 'save returns a promise');
+  promise.then((saveResult) => {
+    assert.equal(saveResult, 'saveResult', 'save proxies to save promise of content');
+  }).finally(() => done());
+});
+
 test('#save handles rejected proxy content', function(assert) {
   let done = assert.async();
   let dummyChangeset = new Changeset(dummyModel);


### PR DESCRIPTION
There's no need to require the proxied object's save() method to return a promise rather than a simple value, and saving a changeset to some data source is not necessarily an asynchronous operation, so this commit adds support for non-promise return values from `save`.